### PR TITLE
Potential `Provider` interface

### DIFF
--- a/provider/node-provider.go
+++ b/provider/node-provider.go
@@ -1,0 +1,1 @@
+package provider

--- a/provider/node-provider.go
+++ b/provider/node-provider.go
@@ -1,1 +1,0 @@
-package provider

--- a/relayer/client.go
+++ b/relayer/client.go
@@ -238,19 +238,19 @@ func (c *Chain) UpgradeClients(dst *Chain, height int64) error {
 	}
 
 	// query proofs on counterparty
-	clientState, proofUpgradeClient, _, err := dst.QueryUpgradedClient(height)
+	csres, err := dst.QueryUpgradedClient(height)
 	if err != nil {
 		return err
 	}
 
-	consensusState, proofUpgradeConsensusState, _, err := dst.QueryUpgradedConsState(height)
+	consres, err := dst.QueryUpgradedConsState(height)
 	if err != nil {
 		return err
 	}
 
-	upgradeMsg := &clienttypes.MsgUpgradeClient{ClientId: c.PathEnd.ClientID, ClientState: clientState,
-		ConsensusState: consensusState, ProofUpgradeClient: proofUpgradeClient,
-		ProofUpgradeConsensusState: proofUpgradeConsensusState, Signer: c.MustGetAddress().String()}
+	upgradeMsg := &clienttypes.MsgUpgradeClient{ClientId: c.PathEnd.ClientID, ClientState: csres.ClientState,
+		ConsensusState: consres.ConsensusState, ProofUpgradeClient: csres.Proof,
+		ProofUpgradeConsensusState: consres.Proof, Signer: c.MustGetAddress().String()}
 
 	msgs := []sdk.Msg{
 		updateMsg,

--- a/relayer/provider.go
+++ b/relayer/provider.go
@@ -1,0 +1,76 @@
+package relayer
+
+import (
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	transfertypes "github.com/cosmos/cosmos-sdk/x/ibc/applications/transfer/types"
+	clienttypes "github.com/cosmos/cosmos-sdk/x/ibc/core/02-client/types"
+	conntypes "github.com/cosmos/cosmos-sdk/x/ibc/core/03-connection/types"
+	chantypes "github.com/cosmos/cosmos-sdk/x/ibc/core/04-channel/types"
+	ibcexported "github.com/cosmos/cosmos-sdk/x/ibc/core/exported"
+	ctypes "github.com/tendermint/tendermint/rpc/core/types"
+)
+
+type Provider interface {
+	ProofProvider
+	DataProvider
+}
+
+type ProofProvider interface {
+	// chain
+	QueryTx(hashHex string) (*ctypes.ResultTx, error)
+	QueryTxs(height uint64, events []string) ([]*ctypes.ResultTx, error)
+
+	// ics 02 - client
+	QueryClientState(height int64, clientid string) (*clienttypes.QueryClientStateResponse, error)
+	QueryClientConsensusState(chainHeight int64, clientid string, clientHeight ibcexported.Height) (*clienttypes.QueryConsensusStateResponse, error)
+	QueryUpgradedClient(height int64) (*clienttypes.QueryClientStateResponse, error)
+	QueryUpgradedConsState(height int64) (*clienttypes.QueryConsensusStateResponse, error)
+
+	// ics 03 - connection
+	QueryConnection(height int64, connectionid string) (*conntypes.QueryConnectionResponse, error)
+
+	// ics 04 - channel
+	QueryChannel(height int64, channelid, portid string) (chanRes *chantypes.QueryChannelResponse, err error)
+	QueryNextSeqRecv(height int64, channelid, portid string) (recvRes *chantypes.QueryNextSequenceReceiveResponse, err error)
+	QueryPacketCommitment(height int64, channelid, portid string, seq uint64) (comRes *chantypes.QueryPacketCommitmentResponse, err error)
+	QueryPacketAcknowledgement(height int64, channelid, portid string, seq uint64) (ackRes *chantypes.QueryPacketAcknowledgementResponse, err error)
+	QueryPacketReceipt(height int64, channelid, portid string, seq uint64) (recRes *chantypes.QueryPacketReceiptResponse, err error)
+}
+
+type DataProvider interface {
+	// NOTE: collections in the above interface should return _all_ of the given object.
+	// this should be done in a performant way with the idea in mind that the dataset could
+	// potentially be very large and this may take a large number of requests
+
+	// chain
+	QueryLatestHeight() (int64, error)
+
+	// bank
+	QueryBalances(addr string) (sdk.Coins, error)
+
+	// staking
+	QueryUnbondingPeriod() (time.Duration, error)
+
+	// ics 02 - client
+	QueryConsensusState(height int64) (ibcexported.ConsensusState, int64, error)
+	QueryClients() ([]*clienttypes.IdentifiedClientState, error)
+
+	// ics 03 - connection
+	QueryConnections() (conns []*conntypes.IdentifiedConnection, err error)
+	QueryConnectionsUsingClient(height int64, clientid string) (clientConns []string, err error)
+
+	// ics 04 - channel
+	QueryChannelClient(height int64, channelid, portid string) (*clienttypes.IdentifiedClientState, error)
+	QueryConnectionChannels(height int64, connectionid string) ([]*chantypes.IdentifiedChannel, error)
+	QueryChannels() ([]*chantypes.IdentifiedChannel, error)
+	QueryPacketCommitments(height uint64, channelid, portid string) (commitments []*chantypes.PacketState, err error)
+	QueryPacketAcknowledgements(height uint64, channelid, portid string) (acknowledgements []*chantypes.PacketState, err error)
+	QueryUnreceivedPackets(height uint64, channelid, portid string, seqs []uint64) ([]uint64, error)
+	QueryUnreceivedAcknowledgements(height uint64, channelid, portid string, seqs []uint64) ([]uint64, error)
+
+	// ics 20 - transfer
+	QueryDenomTrace(denom string) (*transfertypes.DenomTrace, error)
+	QueryDenomTraces(offset, limit uint64, height int64) ([]*transfertypes.DenomTrace, error)
+}

--- a/relayer/provider.go
+++ b/relayer/provider.go
@@ -17,7 +17,25 @@ type Provider interface {
 	DataProvider
 }
 
+// type TxProvider interface {
+// 	CreateClient()
+// 	SubmitMisbehavior()
+// 	UpdateClient()
+// 	ConnectionOpenInit()
+// 	ConnectionOpenTry()
+// 	ConnectionOpenAck()
+// 	ConnectionOpenConfirm()
+// 	ChannelOpenInit()
+// 	ChannelOpenTry()
+// 	ChannelOpenAck()
+// 	ChannelOpenConfirm()
+// 	ChannelCloseInit()
+// 	ChannelCloseConfirm()
+// }
+
 type ProofProvider interface {
+	Init() error
+
 	// chain
 	QueryTx(hashHex string) (*ctypes.ResultTx, error)
 	QueryTxs(height uint64, events []string) ([]*ctypes.ResultTx, error)
@@ -40,7 +58,9 @@ type ProofProvider interface {
 }
 
 type DataProvider interface {
-	// NOTE: collections in the above interface should return _all_ of the given object.
+	Init() error
+
+	// NOTE: collections in this interface should return _all_ of the given object.
 	// this should be done in a performant way with the idea in mind that the dataset could
 	// potentially be very large and this may take a large number of requests
 

--- a/relayer/providers/cosmos/contextual.go
+++ b/relayer/providers/cosmos/contextual.go
@@ -1,0 +1,297 @@
+package cosmos
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/simapp"
+	"github.com/cosmos/cosmos-sdk/simapp/params"
+	"github.com/cosmos/cosmos-sdk/std"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth/tx"
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/proto"
+)
+
+// MakeEncodingConfig returns the encoding txConfig for the chain
+func MakeEncodingConfig(accountprefix string) params.EncodingConfig {
+	amino := codec.NewLegacyAmino()
+	interfaceRegistry := types.NewInterfaceRegistry()
+	marshaler := NewProtoCodec(interfaceRegistry, accountprefix)
+	txCfg := tx.NewTxConfig(marshaler, tx.DefaultSignModes)
+
+	encodingConfig := params.EncodingConfig{
+		InterfaceRegistry: interfaceRegistry,
+		Marshaler:         marshaler,
+		TxConfig:          txCfg,
+		Amino:             amino,
+	}
+
+	std.RegisterLegacyAminoCodec(encodingConfig.Amino)
+	std.RegisterInterfaces(encodingConfig.InterfaceRegistry)
+	simapp.ModuleBasics.RegisterLegacyAminoCodec(encodingConfig.Amino)
+	simapp.ModuleBasics.RegisterInterfaces(encodingConfig.InterfaceRegistry)
+
+	return encodingConfig
+}
+
+// ProtoCodec defines a codec that utilizes Protobuf for both binary and JSON
+// encoding.
+type ProtoCodec struct {
+	interfaceRegistry types.InterfaceRegistry
+	useContext        func() func()
+}
+
+var _ codec.Marshaler = &ProtoCodec{}
+var _ codec.ProtoCodecMarshaler = &ProtoCodec{}
+
+// NewProtoCodec returns a reference to a new ProtoCodec
+func NewProtoCodec(interfaceRegistry types.InterfaceRegistry, accountPrefix string) *ProtoCodec {
+	return &ProtoCodec{interfaceRegistry: interfaceRegistry, useContext: UseSDKContext(accountPrefix)}
+}
+
+var mtx sync.Mutex
+
+func UseSDKContext(prefix string) func() func() {
+	return func() func() {
+		// Ensure we're the only one using the global context,
+		// lock context to begin function
+		mtx.Lock()
+
+		// Mutate the sdkConf
+		sdkConf := sdk.GetConfig()
+		sdkConf.SetBech32PrefixForAccount(prefix, prefix+"pub")
+		sdkConf.SetBech32PrefixForValidator(prefix+"valoper", prefix+"valoperpub")
+		sdkConf.SetBech32PrefixForConsensusNode(prefix+"valcons", prefix+"valconspub")
+
+		// Return the unlock function, caller must lock and ensure that lock is released
+		// before any other function needs to use c.UseSDKContext
+		return mtx.Unlock
+	}
+}
+
+// MarshalBinaryBare implements BinaryMarshaler.MarshalBinaryBare method.
+func (pc *ProtoCodec) MarshalBinaryBare(o codec.ProtoMarshaler) ([]byte, error) {
+	defer pc.useContext()()
+	return o.Marshal()
+}
+
+// MustMarshalBinaryBare implements BinaryMarshaler.MustMarshalBinaryBare method.
+func (pc *ProtoCodec) MustMarshalBinaryBare(o codec.ProtoMarshaler) []byte {
+	bz, err := pc.MarshalBinaryBare(o)
+	if err != nil {
+		panic(err)
+	}
+
+	return bz
+}
+
+// MarshalBinaryLengthPrefixed implements BinaryMarshaler.MarshalBinaryLengthPrefixed method.
+func (pc *ProtoCodec) MarshalBinaryLengthPrefixed(o codec.ProtoMarshaler) ([]byte, error) {
+	defer pc.useContext()()
+	bz, err := pc.MarshalBinaryBare(o)
+	if err != nil {
+		return nil, err
+	}
+
+	var sizeBuf [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(sizeBuf[:], uint64(o.Size()))
+	return append(sizeBuf[:n], bz...), nil
+}
+
+// MustMarshalBinaryLengthPrefixed implements BinaryMarshaler.MustMarshalBinaryLengthPrefixed method.
+func (pc *ProtoCodec) MustMarshalBinaryLengthPrefixed(o codec.ProtoMarshaler) []byte {
+	bz, err := pc.MarshalBinaryLengthPrefixed(o)
+	if err != nil {
+		panic(err)
+	}
+
+	return bz
+}
+
+// UnmarshalBinaryBare implements BinaryMarshaler.UnmarshalBinaryBare method.
+func (pc *ProtoCodec) UnmarshalBinaryBare(bz []byte, ptr codec.ProtoMarshaler) error {
+	defer pc.useContext()()
+	err := ptr.Unmarshal(bz)
+	if err != nil {
+		return err
+	}
+	err = types.UnpackInterfaces(ptr, pc)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// MustUnmarshalBinaryBare implements BinaryMarshaler.MustUnmarshalBinaryBare method.
+func (pc *ProtoCodec) MustUnmarshalBinaryBare(bz []byte, ptr codec.ProtoMarshaler) {
+	if err := pc.UnmarshalBinaryBare(bz, ptr); err != nil {
+		panic(err)
+	}
+}
+
+// UnmarshalBinaryLengthPrefixed implements BinaryMarshaler.UnmarshalBinaryLengthPrefixed method.
+func (pc *ProtoCodec) UnmarshalBinaryLengthPrefixed(bz []byte, ptr codec.ProtoMarshaler) error {
+	defer pc.useContext()()
+	size, n := binary.Uvarint(bz)
+	if n < 0 {
+		return fmt.Errorf("invalid number of bytes read from length-prefixed encoding: %d", n)
+	}
+
+	if size > uint64(len(bz)-n) {
+		return fmt.Errorf("not enough bytes to read; want: %v, got: %v", size, len(bz)-n)
+	} else if size < uint64(len(bz)-n) {
+		return fmt.Errorf("too many bytes to read; want: %v, got: %v", size, len(bz)-n)
+	}
+
+	bz = bz[n:]
+	return pc.UnmarshalBinaryBare(bz, ptr)
+}
+
+// MustUnmarshalBinaryLengthPrefixed implements BinaryMarshaler.MustUnmarshalBinaryLengthPrefixed method.
+func (pc *ProtoCodec) MustUnmarshalBinaryLengthPrefixed(bz []byte, ptr codec.ProtoMarshaler) {
+	if err := pc.UnmarshalBinaryLengthPrefixed(bz, ptr); err != nil {
+		panic(err)
+	}
+}
+
+// MarshalJSON implements JSONMarshaler.MarshalJSON method,
+// it marshals to JSON using proto codec.
+func (pc *ProtoCodec) MarshalJSON(o proto.Message) ([]byte, error) {
+	done := pc.useContext()
+	m, ok := o.(codec.ProtoMarshaler)
+	if !ok {
+		return nil, fmt.Errorf("cannot protobuf JSON encode unsupported type: %T", o)
+	}
+
+	bz, err := codec.ProtoMarshalJSON(m, pc.interfaceRegistry)
+	if err != nil {
+		return []byte{}, err
+	}
+	done()
+	return bz, nil
+}
+
+// MustMarshalJSON implements JSONMarshaler.MustMarshalJSON method,
+// it executes MarshalJSON except it panics upon failure.
+func (pc *ProtoCodec) MustMarshalJSON(o proto.Message) []byte {
+	bz, err := pc.MarshalJSON(o)
+	if err != nil {
+		panic(err)
+	}
+
+	return bz
+}
+
+// UnmarshalJSON implements JSONMarshaler.UnmarshalJSON method,
+// it unmarshals from JSON using proto codec.
+func (pc *ProtoCodec) UnmarshalJSON(bz []byte, ptr proto.Message) error {
+	defer pc.useContext()()
+	m, ok := ptr.(codec.ProtoMarshaler)
+	if !ok {
+		return fmt.Errorf("cannot protobuf JSON decode unsupported type: %T", ptr)
+	}
+
+	err := jsonpb.Unmarshal(strings.NewReader(string(bz)), m)
+	if err != nil {
+		return err
+	}
+
+	return types.UnpackInterfaces(ptr, pc)
+}
+
+// MustUnmarshalJSON implements JSONMarshaler.MustUnmarshalJSON method,
+// it executes UnmarshalJSON except it panics upon failure.
+func (pc *ProtoCodec) MustUnmarshalJSON(bz []byte, ptr proto.Message) {
+	if err := pc.UnmarshalJSON(bz, ptr); err != nil {
+		panic(err)
+	}
+}
+
+// MarshalInterface is a convenience function for proto marshalling interfaces. It packs
+// the provided value, which must be an interface, in an Any and then marshals it to bytes.
+// NOTE: to marshal a concrete type, you should use MarshalBinaryBare instead
+func (pc *ProtoCodec) MarshalInterface(i proto.Message) ([]byte, error) {
+	defer pc.useContext()()
+	if err := assertNotNil(i); err != nil {
+		return nil, err
+	}
+	any, err := types.NewAnyWithValue(i)
+	if err != nil {
+		return nil, err
+	}
+
+	return pc.MarshalBinaryBare(any)
+}
+
+// UnmarshalInterface is a convenience function for proto unmarshaling interfaces. It
+// unmarshals an Any from bz bytes and then unpacks it to the `ptr`, which must
+// be a pointer to a non empty interface with registered implementations.
+// NOTE: to unmarshal a concrete type, you should use UnmarshalBinaryBare instead
+//
+// Example:
+//    var x MyInterface
+//    err := cdc.UnmarshalInterface(bz, &x)
+func (pc *ProtoCodec) UnmarshalInterface(bz []byte, ptr interface{}) error {
+	any := &types.Any{}
+	err := pc.UnmarshalBinaryBare(bz, any)
+	if err != nil {
+		return err
+	}
+
+	return pc.UnpackAny(any, ptr)
+}
+
+// MarshalInterfaceJSON is a convenience function for proto marshalling interfaces. It
+// packs the provided value in an Any and then marshals it to bytes.
+// NOTE: to marshal a concrete type, you should use MarshalJSON instead
+func (pc *ProtoCodec) MarshalInterfaceJSON(x proto.Message) ([]byte, error) {
+	defer pc.useContext()()
+	any, err := types.NewAnyWithValue(x)
+	if err != nil {
+		return nil, err
+	}
+	return pc.MarshalJSON(any)
+}
+
+// UnmarshalInterfaceJSON is a convenience function for proto unmarshaling interfaces.
+// It unmarshals an Any from bz bytes and then unpacks it to the `iface`, which must
+// be a pointer to a non empty interface, implementing proto.Message with registered implementations.
+// NOTE: to unmarshal a concrete type, you should use UnmarshalJSON instead
+//
+// Example:
+//    var x MyInterface  // must implement proto.Message
+//    err := cdc.UnmarshalInterfaceJSON(&x, bz)
+func (pc *ProtoCodec) UnmarshalInterfaceJSON(bz []byte, iface interface{}) error {
+	any := &types.Any{}
+	err := pc.UnmarshalJSON(bz, any)
+	if err != nil {
+		return err
+	}
+	return pc.UnpackAny(any, iface)
+}
+
+// UnpackAny implements AnyUnpacker.UnpackAny method,
+// it unpacks the value in any to the interface pointer passed in as
+// iface.
+func (pc *ProtoCodec) UnpackAny(any *types.Any, iface interface{}) error {
+	defer pc.useContext()()
+	return pc.interfaceRegistry.UnpackAny(any, iface)
+}
+
+// InterfaceRegistry returns the ProtoCodec interfaceRegistry
+func (pc *ProtoCodec) InterfaceRegistry() types.InterfaceRegistry {
+	return pc.interfaceRegistry
+}
+
+func assertNotNil(i interface{}) error {
+	if i == nil {
+		return errors.New("can't marshal <nil> value")
+	}
+	return nil
+}

--- a/relayer/providers/cosmos/data-provider.go
+++ b/relayer/providers/cosmos/data-provider.go
@@ -1,0 +1,1 @@
+package cosmos

--- a/relayer/providers/cosmos/proof-provider.go
+++ b/relayer/providers/cosmos/proof-provider.go
@@ -1,0 +1,1 @@
+package cosmos

--- a/relayer/providers/cosmos/provider.go
+++ b/relayer/providers/cosmos/provider.go
@@ -1,0 +1,41 @@
+package cosmos
+
+import (
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/simapp/params"
+	rpcclient "github.com/tendermint/tendermint/rpc/client"
+	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
+	libclient "github.com/tendermint/tendermint/rpc/jsonrpc/client"
+)
+
+type CosmosProvider struct {
+	ChainID  string
+	Encoding params.EncodingConfig
+	Client   rpcclient.Client
+	debug    bool
+}
+
+func NewCosmosProvider(chainid, rpcaddr, prefix string, timeout time.Duration, debug bool) *CosmosProvider {
+	_, err := newRPCClient(rpcaddr, timeout)
+	if err != nil {
+		panic(err)
+	}
+	_ = MakeEncodingConfig(prefix)
+	return &CosmosProvider{}
+}
+
+func newRPCClient(addr string, timeout time.Duration) (*rpchttp.HTTP, error) {
+	httpClient, err := libclient.DefaultHTTPClient(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	httpClient.Timeout = timeout
+	rpcClient, err := rpchttp.NewWithClient(addr, "/websocket", httpClient)
+	if err != nil {
+		return nil, err
+	}
+
+	return rpcClient, nil
+}


### PR DESCRIPTION
We should separate _all_ the query functionality into a `Provider` abstraction. Each chain would need their own `Provider` instance and different types of chains would have unique `Provider` implementations. Currently all of this is implemented on `Chain` and is tightly coupled the existing implementation. This PR begins to change that and proposes `ProofProvider` and `DataProvider` types to separate concerns and allow for the gradual migration of the non-proof operations to different third party data stores (see postgres indexing work on tendermint).